### PR TITLE
upgrading .net framework to 4.5.2

### DIFF
--- a/SalesforceReportsConnector/Properties/AssemblyInfo.cs
+++ b/SalesforceReportsConnector/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.97.3.0")]
-[assembly: AssemblyFileVersion("0.97.3.0")]
+[assembly: AssemblyVersion("0.98.0.0")]
+[assembly: AssemblyFileVersion("0.98.0.0")]

--- a/SalesforceReportsConnector/SalesforceAPI/EndpointCalls.cs
+++ b/SalesforceReportsConnector/SalesforceAPI/EndpointCalls.cs
@@ -16,6 +16,7 @@ namespace SalesforceReportsConnector.SalesforceAPI
 	{
 		public static T ValidateAccessTokenAndPerformRequest<T>(QvxConnection connection, IDictionary<string, string> connectionParams, Func<string, T> endpointCall)
 		{
+			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 			try
 			{
 				return endpointCall(connectionParams[QvxSalesforceConnectionInfo.CONNECTION_ACCESS_TOKEN]);

--- a/SalesforceReportsConnector/SalesforceReportsConnector.csproj
+++ b/SalesforceReportsConnector/SalesforceReportsConnector.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SalesforceReportsConnector</RootNamespace>
     <AssemblyName>SalesforceReportsConnector</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <NuGetPackageImportStamp>
@@ -28,6 +28,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,6 +49,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -56,7 +59,7 @@
       <HintPath>..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.14.0.3660.1\lib\net40\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="QvxLibrary">
       <HintPath>..\External\QvxLibrary.dll</HintPath>
@@ -114,7 +117,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/SalesforceReportsConnector/app.config
+++ b/SalesforceReportsConnector/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/SalesforceReportsConnector/packages.config
+++ b/SalesforceReportsConnector/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.SqlServer.TransactSql.ScriptDom" version="14.0.3660.1" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
 </packages>

--- a/SetupProject/Product.wxs
+++ b/SetupProject/Product.wxs
@@ -100,7 +100,7 @@
     <UIRef Id="WixUI_Minimal" />
 
     <Property Id="QLIKSENSE_INSTALLDIR">
-        <DirectorySearch Id="QS_ProgramData" Path="C:\ProgramData\Qlik\Sense\" />
+        <DirectorySearch Id="QS_ProgramData" Path="C:\ProgramData\Qlik\Sense\Repository" />
     </Property>
 
     <InstallExecuteSequence>


### PR DESCRIPTION
Upgraded .net to 4.5.2 to support TLS 1.1 and 1.2 for salesforce
Bumped version to 0.98.0.0
Upgraded NewtonSoft.Json
Installer also looks for Repository folder inside of ProgramData to see if Enterprise is installed vs desktop.